### PR TITLE
libmediathek3 : Ersetze HTML-Entitäten in Untertiteln in lesbare Zeichen

### DIFF
--- a/code/script.module.libmediathek3/lib/libmediathek3ttml2srt.py
+++ b/code/script.module.libmediathek3/lib/libmediathek3ttml2srt.py
@@ -70,6 +70,8 @@ def _newSubtitle(url):
 					else:
 						part = part.replace('<'+entry+'>','')
 
+				# Translate html entities in subtitles into readable characters.
+				part = _cleanTitle(part, False)
 
 				buffer += str(i) + '\n'
 				buffer += begin+" --> "+end+"\n"


### PR DESCRIPTION
Hallo 68000a,
vielen Dank erst einmal, dass Du dass Repository von prof-membrane weiterpflegst.
Ich benutze oft die ARD-Mediathek (plugin.video.ardmediathek_de) aus der Gigathek mit Untertiteln in kodi 17.6. Bei den Untertiteln tauchen "&amp;quot;" und andere unübersetzte HTML-Entitäten auf -
zuletzt in ARD-Mediathek / Sendung nach Datum / Das Erste /  Dienstag, 03. März / 20:15 tagesschau  bei 11:27 min : "&amp;quot;Super Tuesday&amp;quot;".
Ich habe auch einen Fix dafür, den ich hiermit, da ich ihn nun schon drei oder vier Updates der libmediathek3 manuell wieder einfügen musste, endlich veröffentlichen möchte.

Ich habe letztlich die Änderung nur für die ARD-Mediathek getestet. Jedoch ist die Änderung so überschaubar, dass sie meiner Meinung nach auch für andere auf libmediathek3 basierende Addons funktionieren müsste.

Ich benutzte parallel auch die 3sat-Mediathek (plugin.video.3satmediathek). (Leider inzwischen ohne Untertitel, da sie vermutlich vom ZDF-Server nicht mehr mitgeliefert werden.) Diese läuft ebenfalls, wenn ich die libmediathek3 so patche.

Ich hoffe der Commit ist nützlich.

Viele Grüße

purewasa



